### PR TITLE
Update PHP to 8.1

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -9,3 +9,13 @@
 "https://backend.{default}/":
     type: upstream
     upstream: "wordpress:http"
+    cache:
+        enabled: true
+        # Base the cache on the session cookies. Ignore all other cookies.
+        cookies:
+            - '/^wordpress_logged_in_/'
+            - '/^wordpress_sec_/'
+            - 'wordpress_test_cookie'
+            - '/^wp-settings-/'
+            - '/^wp-postpass/'
+            - '/^wp-resetpass-/'

--- a/gatsby/package-lock.json
+++ b/gatsby/package-lock.json
@@ -12754,9 +12754,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/wordpress/.platform.app.yaml
+++ b/wordpress/.platform.app.yaml
@@ -5,7 +5,7 @@
 name: wordpress
 
 # The runtime the application uses.
-type: "php:7.4"
+type: 'php:8.1'
 
 # Configuration of the build of the application.
 build:


### PR DESCRIPTION
## Description
PHP7.4 is EOL. Upgrade to 8.1

## Related Issue
https://github.com/platformsh/template-builder/issues/703 

## Motivation and Context
PHP 7.4 is EOL